### PR TITLE
use raw path in trace log(#12150)

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -218,7 +218,7 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 		Time:     now,
 		Proto:    r.Proto,
 		Method:   r.Method,
-		Path:     r.URL.Path,
+		Path:     r.URL.RawPath,
 		RawQuery: redactLDAPPwd(r.URL.RawQuery),
 		Client:   handlers.GetSourceIP(r),
 		Headers:  reqHeaders,


### PR DESCRIPTION
## Description
see #12150

## Motivation and Context
some gateway will escape the request while doing reverse proxy.Cause the signature does not match err.
it's hard to find this kind error using trace now.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
